### PR TITLE
Update makefile linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CXX = g++
-CXXFLAGS = -std=c++17 -Wall -lsqlite3 -lsodium
+CXXFLAGS = -std=c++17 -Wall
+LDLIBS = -lsqlite3 -lsodium
 AUTH_SRC = kernel/auth/AuthManager.cpp
 SHELL_SRC = kernel/shell/ShellCommand.cpp kernel/shell/main_shell.cpp
 INCLUDES = -Ikernel/auth -Ikernel/shell
@@ -7,7 +8,7 @@ INCLUDES = -Ikernel/auth -Ikernel/shell
 all: shell
 
 shell: $(AUTH_SRC) $(SHELL_SRC)
-	$(CXX) $(CXXFLAGS) $(INCLUDES) -o shell $^
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ $(LDLIBS) -o shell
 
 clean:
 	rm -f shell


### PR DESCRIPTION
## Summary
- put library flags into `LDLIBS`
- update `shell` build rule to use standard variables

## Testing
- `make clean`
- `make shell` *(fails: sodium.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c20d690f4832da60929f57f8a9532