### PR TITLE
Wrap C library includes in extern C

### DIFF
--- a/kernel/auth/AuthManager.cpp
+++ b/kernel/auth/AuthManager.cpp
@@ -1,5 +1,7 @@
 #include "AuthManager.hpp"
+extern "C" {
 #include <sodium.h>
+}
 #include <iostream>
 
 AuthManager::AuthManager(const std::string& db_path) {

--- a/kernel/auth/AuthManager.hpp
+++ b/kernel/auth/AuthManager.hpp
@@ -2,7 +2,9 @@
 #define AUTH_MANAGER_HPP
 
 #include <string>
+extern "C" {
 #include <sqlite3.h>
+}
 
 class AuthManager {
 public:

--- a/kernel/auth/test_auth.cpp
+++ b/kernel/auth/test_auth.cpp
@@ -1,5 +1,8 @@
 #include "AuthManager.hpp"
 #include <iostream>
+extern "C" {
+#include <sodium.h>
+}
 
 int main() {
     if (sodium_init() == -1) {

--- a/kernel/shell/main_shell.cpp
+++ b/kernel/shell/main_shell.cpp
@@ -1,6 +1,9 @@
 #include "../auth/AuthManager.hpp"
 #include "ShellCommand.hpp"
 #include <iostream>
+extern "C" {
+#include <sodium.h>
+}
 
 int main() {
     if (sodium_init() == -1) {


### PR DESCRIPTION
## Summary
- add extern "C" block around libsodium headers in `AuthManager.cpp`, `test_auth.cpp`, and `main_shell.cpp`
- wrap sqlite3 header in `AuthManager.hpp`

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_686c41942e9c832dbc7fa3f79a5d5602