### PR TITLE
Add QEMU simulation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Flinstone-OS
+
+This project contains a toy shell and a small experimental kernel. The shell
+builds and runs on Linux using SQLite and libsodium. The kernel and bootloader
+can be run in an emulator for testing.
+
+See `README.txt` for build instructions and `simulate_os.sh` for running the
+kernel under QEMU.
+

--- a/README.txt
+++ b/README.txt
@@ -12,3 +12,17 @@ To build the shell with authentication and account control:
    ./shell
 
 This will launch an interactive terminal with user login and command execution.
+
+Simulation Mode:
+----------------
+You can boot Flinstone OS in an emulator instead of writing it to a disk.
+
+1. Install QEMU:
+   sudo apt install qemu-system-x86
+
+2. Run the simulator script:
+   ./simulate_os.sh
+
+The script builds the bootloader and kernel, creates a disk image, and
+launches QEMU with that image so you can experiment with the OS from an
+IDE or terminal.

--- a/simulate_os.sh
+++ b/simulate_os.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+BOOTDIR="flinstone_os_drivers/bootloader"
+KERNELDIR="flinstone_os_drivers/kernel"
+
+if ! command -v qemu-system-i386 >/dev/null 2>&1; then
+    echo "qemu-system-i386 not found. Please install QEMU." >&2
+    exit 1
+fi
+
+# Build bootloader
+make -C "$BOOTDIR"
+
+# Build kernel (fallback to host tools if cross compiler missing)
+if command -v i686-elf-gcc >/dev/null 2>&1; then
+    make -C "$KERNELDIR"
+else
+    make -C "$KERNELDIR" CC=gcc LD='ld -m elf_i386'
+fi
+
+# Create disk image
+dd if=/dev/zero of=os-image.bin bs=512 count=2880 2>/dev/null
+dd if="$BOOTDIR/boot.bin" of=os-image.bin conv=notrunc 2>/dev/null
+dd if="$KERNELDIR/kernel.bin" of=os-image.bin bs=512 seek=1 conv=notrunc 2>/dev/null
+
+# Launch QEMU
+qemu-system-i386 os-image.bin


### PR DESCRIPTION
## Summary
- add `simulate_os.sh` to build bootloader and kernel and launch QEMU
- document simulation mode in README files

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_686c4c1c9474832db92973290f21d628